### PR TITLE
JWT認証の実装（フロント）

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1,0 +1,19 @@
+import axiosBase from "axios";
+
+const api = axiosBase.create({
+  baseURL: "http://localhost:3001",
+  responseType: "json",
+});
+
+const authorizationHeader = (token: String) => {
+  return {
+    headers: {
+      Authorization: `Authorization ${token}`
+    }
+  }
+};
+
+
+// 関数：Rails側へ送る際のHTTPリクエスト
+export const createUser = async (name: String, token: String) =>
+  await api.post('/api/v1/users', {name}, authorizationHeader(token));

--- a/hooks/userContext.tsx
+++ b/hooks/userContext.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, createContext, useContext } from "react";
 import { firebase } from "../firebaseClient";
 import nookies from "nookies";
 import { useRouter } from "next/router";
+import { createUser } from "../api"
 
 interface UserContextProps {
   user: firebase.User;
@@ -45,7 +46,7 @@ export const AuthProvider = ({ children }: any) => {
   }, []);
 
   // ユーザーをログインさせる関数
-  const login = async (email: any, password: any) => {
+  const login = async (email: String, password: String) => {
     try {
       // ①ユーザーが入力した emailとpasswordを Firebaseに送る
       // ②emailとpasswordを検証する（firebase側）
@@ -57,14 +58,16 @@ export const AuthProvider = ({ children }: any) => {
   }
 
   // 新しいユーザーを作成しログインさせる関数
-  const signup = async (email: any, password: any) => {
+  const signup = async (email: String, password: String, name: String) => {
     try {
       // ①ユーザーが入力した emailとpasswordを Firebaseに送る
       // ②emailとpasswordを保存する（firebase側）
       const { user } = await firebase
         .auth()
         .createUserWithEmailAndPassword(email, password);
-      return user;
+        if (user === null) return;
+        const idToken = await user.getIdToken();
+        return await createUser(name ,idToken)
       // ④user情報からidTokenを取り出して、cookieに保存する
     } catch (e) {
       const { code } = e;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^14.14.35",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.2",
+    "axios": "^0.21.1",
     "firebase": "^8.3.0",
     "next": "10.0.9",
     "nookies": "^2.5.2",

--- a/pages/user/signup.tsx
+++ b/pages/user/signup.tsx
@@ -11,9 +11,9 @@ export function SignupPage() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
-  const onSubmit = async (data: { email: string; password: string; }) => {
+  const onSubmit = async (data: { email: string; password: string; name: string}) => {
     setIsLoading(true);
-    const user = await signup(data.email, data.password);
+    const user = await signup(data.email, data.password, data.name);
     setIsLoading(false)
     if (user) {
       alert("新規登録が成功しました！")
@@ -28,6 +28,24 @@ export function SignupPage() {
       </header>
 
       <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="FormControll">
+          <label htmlFor="" className="FormLabel">
+            ユーザー名
+          </label>
+          <input
+            type="name"
+            name="name"
+            className="FormTextInput"
+            placeholder="田中太郎"
+            ref={register({
+              required: true,
+            })}
+          />
+          {errors.email && (
+            <span className="sub red">メールアドレスを入力してください。</span>
+          )}
+        </div>
+
         <div className="FormControll">
           <label htmlFor="" className="FormLabel">
             メールアドレス


### PR DESCRIPTION
## 概要
#1 から更に以下のような追加実装を行いました！

```
・サーバー（Rails）にリクエストを送信する実装を行った（api.tsファイル）
・新規登録時にユーザー名のフォームを追加し、これをRails側のDBに保存するように実装
```
## 設計内容
### ユーザー登録時
[![Image from Gyazo](https://i.gyazo.com/28eb40518b687cb3f777f6c4e9de0832.png)](https://gyazo.com/28eb40518b687cb3f777f6c4e9de0832)

### ユーザーログイン時
[![Image from Gyazo](https://i.gyazo.com/121f9b34a17dfd86fc33f680325bde0e.png)](https://gyazo.com/121f9b34a17dfd86fc33f680325bde0e)

### 認証が必要なページにアクセスした時
[![Image from Gyazo](https://i.gyazo.com/ed4414780ce5cbe2085f288f22656ae4.png)](https://gyazo.com/ed4414780ce5cbe2085f288f22656ae4)

### 元データ
https://www.figma.com/file/Tfl2cmx61g8Vwky0S1IuZQ/skipla%E8%A8%AD%E8%A8%88%E7%94%A8?node-id=0%3A1

### シークエンス図
![名称未設定のノート (1)-30](https://user-images.githubusercontent.com/44918658/111283493-8a5aa980-8682-11eb-90db-7138a8318452.jpg)
